### PR TITLE
Fixed error:  Uncaught ArgumentCountError: Too few arguments to funct…

### DIFF
--- a/public/main.php
+++ b/public/main.php
@@ -210,7 +210,7 @@ class Brizy_Public_Main {
 			'editorData'    => $config_object,
 			'editorVersion' => BRIZY_EDITOR_VERSION,
 			'iframe_url'    => $iframe_url,
-			'page_title'    => apply_filters( 'the_title', $this->post->get_wp_post()->post_title )
+			'page_title'    => apply_filters( 'the_title', $this->post->get_wp_post()->post_title, $this->post->get_wp_post()->ID )
 		);
 
 		if ( defined( 'BRIZY_DEVELOPMENT' ) ) {


### PR DESCRIPTION
Woocommerce adds a function(```unsupported_theme_title_filter```) to hook ```the_title``` which requiere two arguments; when we do ```apply_filters( 'the_title', $this->post->get_wp_post()->post_title )``` we send only one.
```
Uncaught ArgumentCountError: Too few arguments to function WC_Template_Loader::unsupported_theme_title_filter(), 1 passed in /home/viorel/www/wp/wp-includes/class-wp-hook.php on line 286 and exactly 2 expected in /home/viorel/www/wp/wp-content/plugins/woocommerce/includes/class-wc-template-loader.php:399 Stack trace: #0 /home/viorel/www/wp/wp-includes/class-wp-hook.php(286): WC_Template_Loader::unsupported_theme_title_filter('Template A') #1 /home/viorel/www/wp/wp-includes/plugin.php(203): WP_Hook->apply_filters('Template A', Array) #2 /home/viorel/www/wp/wp-content/plugins/brizy/public/main.php(213): apply_filters('the_title', 'Template A') #3 /home/viorel/www/wp/wp-includes/class-wp-hook.php(286): Brizy_Public_Main->templateInclude('/home/viorel/ww...') #4 /home/viorel/www/wp/wp-includes/plugin.php(203): WP_Hook->apply_filters('/home/viorel/ww...', Array) #5 /home/viorel/www/wp/wp-includes/template-loader.php(73): apply_filters('template_includ...', '/home/viorel/ww...') #6 /home/viorel/www/wp/wp-blog-heade in /home/viorel/www/wp/wp-content/plugins/woocommerce/includes/class-wc-template-loader.php on line 399. Output triggered in /home/viorel/www/wp/wp-content/plugins/query-monitor/collectors/php_errors.php on line 147
```