### PR TITLE
Jump over parse_query hooks

### DIFF
--- a/editor/asset/media-asset-processor.php
+++ b/editor/asset/media-asset-processor.php
@@ -116,14 +116,12 @@ class Brizy_Editor_Asset_MediaAssetProcessor implements Brizy_Editor_Content_Pro
 			FROM {$posts_table}
 			INNER JOIN {$meta_table}
 			ON ( {$posts_table}.ID = {$meta_table}.post_id )
-			WHERE 1=1
-			AND ( ( wp_postmeta.meta_key = 'brizy_attachment_uid'
-			AND wp_postmeta.meta_value = %s ) )
-			AND wp_posts.post_type = 'attachment'
-			AND ((wp_posts.post_status = 'inherit'))
+			WHERE
+			( {$meta_table}.meta_key = 'brizy_attachment_uid' AND {$meta_table}.meta_value = %s )
+			AND {$posts_table}.post_type = 'attachment'
+			AND {$posts_table}.post_status = 'inherit'
 			GROUP BY {$posts_table}.ID
-			ORDER BY {$posts_table}.post_date DESC
-			LIMIT 0, 5",
+			ORDER BY {$posts_table}.post_date DESC",
 			$uid
 		) );
 

--- a/editor/asset/media-asset-processor.php
+++ b/editor/asset/media-asset-processor.php
@@ -116,8 +116,7 @@ class Brizy_Editor_Asset_MediaAssetProcessor implements Brizy_Editor_Content_Pro
 			FROM {$posts_table}
 			INNER JOIN {$meta_table}
 			ON ( {$posts_table}.ID = {$meta_table}.post_id )
-			WHERE
-			( {$meta_table}.meta_key = 'brizy_attachment_uid' AND {$meta_table}.meta_value = %s )
+			WHERE ( {$meta_table}.meta_key = 'brizy_attachment_uid' AND {$meta_table}.meta_value = %s )
 			AND {$posts_table}.post_type = 'attachment'
 			AND {$posts_table}.post_status = 'inherit'
 			GROUP BY {$posts_table}.ID


### PR DESCRIPTION
Some themes/plugins adds function like this to parse_query:
```
function my_files_only( $wp_query ) {
	if ( $wp_query->query_vars['post_type'] == "attachment" ) {
		if ( ! current_user_can( 'level_5' ) ) {
			global $current_user;
			$wp_query->set( 'author', $current_user->id );
		}
	}
}

add_filter( 'parse_query', 'my_files_only' );
```
That means when the attachment is extracted from db in the query vars is inserted one more var in the case above by author ```$wp_query->set( 'author', $current_user->id );```; but this attachment can be added by other user and it will not be get form db.
