### PR TITLE
Don't insert builder content on each execution of the hook the_content

### DIFF
--- a/editor/content/content-processor.php
+++ b/editor/content/content-processor.php
@@ -1,0 +1,13 @@
+<?php
+
+class Brizy_Editor_Content_ContentProcessor implements Brizy_Editor_Content_ProcessorInterface {
+
+	public function process( $content ) {
+
+		if ( empty( $content ) ) {
+			return '';
+		}
+
+		return $content . '<!-- ___brizy-content___ -->';
+	}
+}

--- a/editor/content/processor-interface.php
+++ b/editor/content/processor-interface.php
@@ -1,10 +1,4 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: alex
- * Date: 4/18/18
- * Time: 10:46 AM
- */
 
 interface Brizy_Editor_Content_ProcessorInterface {
 	public function process( $content );

--- a/editor/post.php
+++ b/editor/post.php
@@ -403,7 +403,8 @@ class Brizy_Editor_Post extends Brizy_Admin_Serializable {
 
 		$brizy_editor_compiled_html = new Brizy_Editor_CompiledHtml( $this->get_compiled_html() );
 
-		$asset_processors = apply_filters( 'brizy_content_processors', $asset_processors, $project, $post );
+		$asset_processors   = apply_filters( 'brizy_content_processors', $asset_processors, $project, $post );
+		$asset_processors[] = new Brizy_Editor_Content_ContentProcessor();
 
 		$brizy_editor_compiled_html->setProcessors( $asset_processors );
 

--- a/public/main.php
+++ b/public/main.php
@@ -343,6 +343,7 @@ class Brizy_Public_Main {
 	 * @throws Exception
 	 */
 	public function insert_page_content( $content ) {
+
 		if ( ! $this->post->get_compiled_html() ) {
 			$compiled_html_body = $this->post->get_compiled_html_body();
 			$content            = Brizy_SiteUrlReplacer::restoreSiteUrl( $compiled_html_body );
@@ -351,6 +352,8 @@ class Brizy_Public_Main {
 			$compiled_page = $this->post->get_compiled_page( $this->project );
 			$content       = $compiled_page->get_body();
 		}
+
+		remove_filter( 'the_content', array( $this, 'insert_page_content' ), - 10000 );
 
 		return $content;
 	}

--- a/public/main.php
+++ b/public/main.php
@@ -344,6 +344,10 @@ class Brizy_Public_Main {
 	 */
 	public function insert_page_content( $content ) {
 
+		if ( false === strpos( $content, '___brizy-content___' ) ) {
+			return $content;
+		}
+
 		if ( ! $this->post->get_compiled_html() ) {
 			$compiled_html_body = $this->post->get_compiled_html_body();
 			$content            = Brizy_SiteUrlReplacer::restoreSiteUrl( $compiled_html_body );
@@ -352,8 +356,6 @@ class Brizy_Public_Main {
 			$compiled_page = $this->post->get_compiled_page( $this->project );
 			$content       = $compiled_page->get_body();
 		}
-
-		remove_filter( 'the_content', array( $this, 'insert_page_content' ), - 10000 );
 
 		return $content;
 	}


### PR DESCRIPTION
There are many themes using mutiple times of the hook the_content for example this theme: https://themeforest.net/item/april-wonderful-fashion-woocommerce-wordpress-theme/20647488?s_rank=1
They extract some content from theme options for header/footer and apply filters on it, one of them is the the_content so when we are in a page buildin with brizy the content of the builder is showing for each apply filter the_content.
Related issue: https://github.com/bagrinsergiu/blox-editor/issues/3305