### PR TITLE
Remove content length header

### DIFF
--- a/editor/asset/static-file.php
+++ b/editor/asset/static-file.php
@@ -127,7 +127,6 @@ abstract class Brizy_Editor_Asset_StaticFile {
 			// send headers
 			$headers                   = array();
 			$headers['Content-Type']   = $this->get_mime( $filename, 1 );
-			$headers['Content-Length'] = strlen( $content );
 			$headers['Cache-Control']  = 'max-age=600';
 
 			foreach ( $headers as $key => $val ) {

--- a/public/asset-proxy.php
+++ b/public/asset-proxy.php
@@ -77,7 +77,6 @@ class Brizy_Public_AssetProxy extends Brizy_Public_AbstractProxy {
 			// send headers
 			$headers                   = array();
 			$headers['Content-Type']   = $this->get_mime( $new_path, 1 );
-			$headers['Content-Length'] = strlen( $content );
 			$headers['Cache-Control']  = 'max-age=600';
 
 			foreach ( $headers as $key => $val ) {


### PR DESCRIPTION
There are conflicts with some cache plugins: wp rocket plugin, w3 total cache.