### PR TITLE
enable autoptimize_filter_js_noptimize only by GET key iframe

### DIFF
--- a/compatibilities/autoptimize.php
+++ b/compatibilities/autoptimize.php
@@ -12,15 +12,7 @@ class Brizy_Compatibilities_Autoptimize {
 	 * When we are in post build mode with brizy we disable it.
 	 */
 	public function disable_js_optimize() {
-		$pid = Brizy_Editor::get()->currentPostId();
-
-		if ( ! $pid ) {
-			return;
-		}
-
-		$post = Brizy_Editor_Post::get( $pid );
-
-		if ( $post && $post->uses_editor() && isset( $_GET[ Brizy_Editor_Constants::EDIT_KEY_IFRAME ] ) ) {
+		if ( isset( $_GET[ Brizy_Editor_Constants::EDIT_KEY_IFRAME ] ) ) {
 			add_filter( 'autoptimize_filter_js_noptimize', '__return_true' );
 		}
 	}


### PR DESCRIPTION
When Brizy editor doesn't support this post type that we get by: ```Brizy_Editor_Post::get( $pid )``` it is getting an exception triggered in the function ```checkIfPostTypeIsSupported```