### PR TITLE
Browser tab title

### DIFF
--- a/public/main.php
+++ b/public/main.php
@@ -50,6 +50,7 @@ class Brizy_Public_Main {
 			// When some plugins want to redirect to their templates.
 			remove_all_actions( 'template_redirect' );
 			add_action( 'template_include', array( $this, 'templateInclude' ), 10000 );
+
 		} elseif ( $this->is_editing_page_with_editor_on_iframe() && Brizy_Editor::is_user_allowed() ) {
 			add_action( 'template_include', array( $this, 'templateIncludeForEditor' ), 10000 );
 			add_filter( 'show_admin_bar', '__return_false' );
@@ -217,11 +218,19 @@ class Brizy_Public_Main {
 			get_permalink( $this->post->get_wp_post()->ID )
 		);
 
+		$favicon = '';
+		if ( has_site_icon() ) {
+			ob_start(); ob_clean();
+				wp_site_icon();
+			$favicon = ob_get_clean();
+		}
+
 		$context = array(
 			'editorData'    => $config_object,
 			'editorVersion' => BRIZY_EDITOR_VERSION,
 			'iframe_url'    => $iframe_url,
-			'page_title'    => apply_filters( 'the_title', $this->post->get_wp_post()->post_title, $this->post->get_wp_post()->ID )
+			'page_title'    => apply_filters( 'the_title', $this->post->get_wp_post()->post_title, $this->post->get_wp_post()->ID ),
+			'favicon'       => $favicon
 		);
 
 		if ( defined( 'BRIZY_DEVELOPMENT' ) ) {

--- a/public/views/page.html.twig
+++ b/public/views/page.html.twig
@@ -8,6 +8,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <link rel="stylesheet" href="{{ assetsUrl }}/editor/css/editor.css?ver={{ editorVersion }}">
+        {{ favicon | raw }}
         <style id="brz-ed-page-curtain-style">@keyframes spin{100%{transform:rotate(360deg)}}.brz-ed-page-curtain{position:fixed;left:0;right:0;top:0;bottom:0;background-color:#141923;z-index:1000}.brz-ed-page-spinner,.brz-ed-page-spinner:after,.brz-ed-page-spinner:before{content:"";position:absolute;top:50%;left:50%;border:3px solid transparent;border-radius:50%;animation:spin 1s linear infinite}.brz-ed-page-spinner{width:100px;height:100px;margin:-50px 0 0 -50px;border-top-color:#22b0da;animation-duration:2.5s}.brz-ed-page-spinner:after{width:80px;height:80px;margin:-40px 0 0 -40px;border-right-color:#ed2164;animation-duration:2s}.brz-ed-page-spinner:before{width:60px;height:60px;margin:-30px 0 0 -30px;border-bottom-color:#fff}.brz-ed-load-error{display:none;width:70%;position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);color:#fff;text-align:center}.brz-ed-load-error p:first-child{font-size:30px;margin-bottom:20px}.brz-ed-load-error p:last-child{font-size:18px}.brz-ed-load-error code{background-color:gray;padding:1px;font-size:15px}.brz-ed-page-curtain.has-load-error .brz-ed-page-spinner{display:none}.brz-ed-page-curtain.has-load-error .brz-ed-load-error{display:block}</style>
     </head>
     <body class="brz brz-ed" style="margin: 0;">

--- a/public/views/templates/brizy-blank-template.php
+++ b/public/views/templates/brizy-blank-template.php
@@ -13,7 +13,13 @@
     <meta charset="<?php bloginfo( 'charset' ); ?>">
     <link rel="profile" href="http://gmpg.org/xfn/11">
     <link rel="pingback" href="<?php bloginfo( 'pingback_url' ); ?>">
-    <?php wp_head(); ?>
+	<?php
+        if ( ! current_theme_supports( 'title-tag' ) ) {
+            echo '<title>' . wp_get_document_title() . '</title>';
+        }
+
+        wp_head();
+	?>
 </head>
 <body <?php body_class(); ?>>
 <?php while (have_posts()) : the_post() ?>

--- a/public/views/templates/brizy-template.php
+++ b/public/views/templates/brizy-template.php
@@ -8,7 +8,13 @@
     <meta charset="<?php bloginfo( 'charset' ); ?>">
     <link rel="profile" href="http://gmpg.org/xfn/11">
     <link rel="pingback" href="<?php bloginfo( 'pingback_url' ); ?>">
-    <?php wp_head(); ?>
+    <?php
+        if ( ! current_theme_supports( 'title-tag' ) ) {
+            echo '<title>' . wp_get_document_title() . '</title>';
+        }
+
+        wp_head();
+    ?>
 </head>
 <body class="brz">
 <?php do_action('brizy_template_content') ?>


### PR DESCRIPTION
When the theme doesn't support ```title-tag``` and the user uses the template ```Brizy Template``` then we don't have any title tag for the browser tab.
Some old themes have an old implementation of the tag title. They have in the header.php something like that: ```<title><?php wp_title( '|', true, 'right' ); ?></title>```.
Since wordpress 4.1 theme authors must use something like that:
 ```
function theme_slug_setup() {
   add_theme_support( 'title-tag' );
}
add_action( 'after_setup_theme', 'theme_slug_setup' );
```
but not all theme moved their themes to the new version so when is ```Brizy Template``` we don't have tag title because we don't use header.php of the theme.
Further information:
https://make.wordpress.org/core/2014/10/29/title-tags-in-4-1/