### PR TITLE
Get templates depending on the post type

### DIFF
--- a/editor.php
+++ b/editor.php
@@ -49,7 +49,6 @@ class Brizy_Editor {
 			Brizy_Admin_Rules_Api::_init();
 		}
 
-		add_filter( "brizy:templates", array( $this, 'filterPublicTemplates' ) );
 		add_filter( "wp_revisions_to_keep", array( $this, 'revisionsToKeep' ), 10, 2 );
 		add_action( 'wp_head', array( $this, 'brizy_settings_header' ) );
 		add_action( 'wp_footer', array( $this, 'brizy_settings_footer' ) );
@@ -167,27 +166,6 @@ class Brizy_Editor {
 
 		return $num;
 	}
-
-
-	/**
-	 * @param $templates
-	 *
-	 * @return array
-	 */
-	public function filterPublicTemplates( $templates ) {
-
-		$list = wp_get_theme()->get_page_templates();
-
-		foreach ( $list as $key => $title ) {
-			$templates[] = array(
-				'id'    => $key,
-				'title' => $title
-			);
-		}
-
-		return $templates;
-	}
-
 
 	/**
 	 * @param $templates

--- a/editor/editor/editor.php
+++ b/editor/editor/editor.php
@@ -94,7 +94,7 @@ class Brizy_Editor_Editor_Editor {
 			$preview_post_link = $this->getPreviewUrl( $this->post->get_wp_post() );
 
 			$change_template_url = set_url_scheme( admin_url( 'admin-post.php?post=' . $this->get_post()->get_parent_id() . '&action=_brizy_change_template' ) );
-			$templates           = apply_filters( "brizy:templates", $this->post->get_templates() );
+			$templates           = $this->post->get_templates();
 			$isTemplate          = $parent_post_type == Brizy_Admin_Templates::CP_TEMPLATE;
 			$isPopup             = $parent_post_type == Brizy_Admin_Popups_Main::CP_POPUP;
 		}

--- a/editor/post.php
+++ b/editor/post.php
@@ -773,15 +773,23 @@ class Brizy_Editor_Post extends Brizy_Admin_Serializable {
 	 * @return array
 	 */
 	public function get_templates() {
-		$type = get_post_type( $this->get_id() );
-		$list = array(
+
+		$type      = get_post_type( $this->get_id() );
+		$templates = array(
 			array(
 				'id'    => '',
-				'title' => __( 'Default' )
+				'title' => __( 'Default', 'brizy' )
 			)
 		);
 
-		return apply_filters( "brizy:$type:templates", $list );
+		foreach ( wp_get_theme()->get_page_templates( null, $type ) as $key => $title ) {
+			$templates[] = [
+				'id'    => $key,
+				'title' => $title
+			];
+		}
+
+		return apply_filters( "brizy:$type:templates", $templates );
 	}
 
 	/**


### PR DESCRIPTION
If there is a template added for only post type page when we get it for every post we edit with brizy. For example, if I have a template added only for pages:
```
/**
 * Template Name: Visual Builder Template
 */
```
then I edit an article(post type post) with brizy and choose this template it won't save.
This pr will pull only templates added for the current editing post's post type.