### PR TITLE
WPML compatibility

### DIFF
--- a/admin/blocks/main.php
+++ b/admin/blocks/main.php
@@ -57,11 +57,12 @@ class Brizy_Admin_Blocks_Main {
 		}
 
 		$blocks = get_posts( array(
-			'post_type'      => Brizy_Admin_Blocks_Main::CP_GLOBAL,
-			'posts_per_page' => - 1,
-			'post_status'    => 'publish',
-			'orderby'        => 'ID',
-			'order'          => 'ASC',
+			'post_type'        => Brizy_Admin_Blocks_Main::CP_GLOBAL,
+			'posts_per_page'   => - 1,
+			'post_status'      => 'publish',
+			'orderby'          => 'ID',
+			'order'            => 'ASC',
+			'suppress_filters' => false,
 		) );
 
 		foreach ( $blocks as $block ) {
@@ -71,11 +72,12 @@ class Brizy_Admin_Blocks_Main {
 		}
 
 		$blocks = get_posts( array(
-			'post_type'      => Brizy_Admin_Blocks_Main::CP_SAVED,
-			'posts_per_page' => - 1,
-			'post_status'    => 'publish',
-			'orderby'        => 'ID',
-			'order'          => 'ASC',
+			'post_type'        => Brizy_Admin_Blocks_Main::CP_SAVED,
+			'posts_per_page'   => - 1,
+			'post_status'      => 'publish',
+			'orderby'          => 'ID',
+			'order'            => 'ASC',
+			'suppress_filters' => false,
 		) );
 
 		foreach ( $blocks as $block ) {

--- a/compatibilities/init.php
+++ b/compatibilities/init.php
@@ -24,7 +24,7 @@ class Brizy_Compatibilities_Init {
 			new Brizy_Compatibilities_Autoptimize();
 		}
 
-		if ( defined( 'ICL_SITEPRESS_VERSION' ) ) {
+		if ( apply_filters( 'wpml_setting', false, 'setup_complete' ) ) {
 			new Brizy_Compatibilities_WPML();
 		}
 

--- a/compatibilities/wpml.php
+++ b/compatibilities/wpml.php
@@ -14,7 +14,7 @@ class Brizy_Compatibilities_WPML {
 		add_filter( 'wpml_pb_should_body_be_translated', array( $this, 'remove_body' ), 10, 2 );
 		add_action( 'wpml_pro_translation_completed', array( $this, 'save_post' ), 10, 3 );
 
-		add_filter( 'wpml_basket_is_base64_item', '__return_false' );
+		add_filter( 'wpml_basket_base64_item', '__return_false' );
 		add_filter( 'wpml_document_view_item_link', '__return_empty_string' );
 		add_filter( 'wpml_document_edit_item_link', '__return_empty_string' );
 	}

--- a/editor/block.php
+++ b/editor/block.php
@@ -131,11 +131,12 @@ class Brizy_Editor_Block extends Brizy_Editor_Post {
 	public static function getBlocksByType( $type, $arags = array() ) {
 
 		$filterArgs = array(
-			'post_type'      => $type,
-			'posts_per_page' => - 1,
-			'post_status'    => 'any',
-			'orderby'        => 'ID',
-			'order'          => 'ASC',
+			'post_type'        => $type,
+			'posts_per_page'   => - 1,
+			'post_status'      => 'any',
+			'orderby'          => 'ID',
+			'order'            => 'ASC',
+			'suppress_filters' => false,
 		);
 		$filterArgs = array_merge( $filterArgs, $arags );
 

--- a/wpml-config.xml
+++ b/wpml-config.xml
@@ -1,0 +1,143 @@
+<wpml-config>
+    <custom-types>
+        <custom-type translate="1" display-as-translated="1">brizy-global-block</custom-type>
+        <custom-type translate="1" display-as-translated="1">brizy-saved-block</custom-type>
+        <custom-type translate="1" display-as-translated="1">brizy_template</custom-type>
+    </custom-types>
+    <custom-fields>
+        <custom-field action="copy">brizy_post_uid</custom-field>
+        <custom-field action="ignore">brizy-need-compile</custom-field>
+        <custom-field action="copy">brizy-post-plugin-version</custom-field>
+        <custom-field action="copy">brizy-post-editor-version</custom-field>
+        <custom-field action="copy">brizy-post-compiler-version</custom-field>
+        <custom-field action="translate">brizy</custom-field>
+    </custom-fields>
+    <custom-fields-texts>
+        <key name="brizy">
+            <key name="brizy-post">
+                <key name="editor_data">
+                    <key name="value">
+                        <key name="text" />
+                        <key name="items">
+                            <key name="*">
+                                <key name="value">
+                                    <key name="text" />
+                                    <key name="items">
+                                        <key name="*">
+                                            <key name="value">
+                                                <key name="text" />
+                                                <key name="items">
+                                                    <key name="*">
+                                                        <key name="value">
+                                                            <key name="text" />
+                                                            <key name="items">
+                                                                <key name="*">
+                                                                    <key name="value">
+                                                                        <key name="text" />
+                                                                        <key name="items">
+                                                                            <key name="*">
+                                                                                <key name="value">
+                                                                                    <key name="text" />
+                                                                                    <key name="items">
+                                                                                        <key name="*">
+                                                                                            <key name="value">
+                                                                                                <key name="text" />
+                                                                                                <key name="items">
+                                                                                                    <key name="*">
+                                                                                                        <key name="value">
+                                                                                                            <key name="text" />
+                                                                                                            <key name="items">
+                                                                                                                <key name="*">
+                                                                                                                    <key name="value">
+                                                                                                                        <key name="text" />
+                                                                                                                        <key name="items">
+                                                                                                                            <key name="*">
+                                                                                                                                <key name="value">
+                                                                                                                                    <key name="text" /></key>
+                                                                                                                            </key>
+                                                                                                                        </key>
+                                                                                                                    </key>
+                                                                                                                </key>
+                                                                                                            </key>
+                                                                                                        </key>
+                                                                                                    </key>
+                                                                                                </key>
+                                                                                            </key>
+                                                                                        </key>
+                                                                                    </key>
+                                                                                </key>
+                                                                            </key>
+                                                                        </key>
+                                                                    </key>
+                                                                </key>
+                                                            </key>
+                                                        </key>
+                                                    </key>
+                                                </key>
+                                            </key>
+                                        </key>
+                                    </key>
+                                </key>
+                            </key>
+                        </key>
+                    </key>
+                    <key name="items">
+                        <key name="*">
+                            <key name="value">
+                                <key name="text" />
+                                <key name="items">
+                                    <key name="*">
+                                        <key name="value">
+                                            <key name="text" />
+                                            <key name="items">
+                                                <key name="*">
+                                                    <key name="value">
+                                                        <key name="text" />
+                                                        <key name="items">
+                                                            <key name="*">
+                                                                <key name="value">
+                                                                    <key name="text" />
+                                                                    <key name="items">
+                                                                        <key name="*">
+                                                                            <key name="value">
+                                                                                <key name="text" />
+                                                                                <key name="items">
+                                                                                    <key name="*">
+                                                                                        <key name="value">
+                                                                                            <key name="text" />
+                                                                                            <key name="items">
+                                                                                                <key name="*">
+                                                                                                    <key name="value">
+                                                                                                        <key name="text" />
+                                                                                                        <key name="items">
+                                                                                                            <key name="*">
+                                                                                                                <key name="value">
+                                                                                                                    <key name="text" /></key>
+                                                                                                            </key>
+                                                                                                        </key>
+                                                                                                    </key>
+                                                                                                </key>
+                                                                                            </key>
+                                                                                        </key>
+                                                                                    </key>
+                                                                                </key>
+                                                                            </key>
+                                                                        </key>
+                                                                    </key>
+                                                                </key>
+                                                            </key>
+                                                        </key>
+                                                    </key>
+                                                </key>
+                                            </key>
+                                        </key>
+                                    </key>
+                                </key>
+                            </key>
+                        </key>
+                    </key>
+                </key>
+            </key>
+        </key>
+    </custom-fields-texts>
+</wpml-config>


### PR DESCRIPTION
This pull request adds support for translating Brizy with any of WPML's translation editors.

- Adds 'suppress_filters => false' to `get_posts` calls so that WPML's filters can do their job
- Adds code to decode and encode Brizy's custom field
- Adds code to re-compile the page after the translated values are saved

Requires WPML 4.3.7 with the String Translation and Translation Management add-ons.