### PR TITLE
Add click outside exceptions for jquery ui widgets

### DIFF
--- a/public/editor-src/editor/js/component/Options/types/Popover.jsx
+++ b/public/editor-src/editor/js/component/Options/types/Popover.jsx
@@ -52,7 +52,9 @@ class PopoverOptionType extends React.Component {
       ...(TARGET === "WP"
         ? [
             ".media-modal", // class of the WP media modal
-            ".media-modal-backdrop"
+            ".media-modal-backdrop",
+            ".ui-widget",
+            ".ui-widget-overlay"
           ]
         : [])
     ];

--- a/public/editor-src/editor/js/component/Toolbar/CollapsibleToolbar.tsx
+++ b/public/editor-src/editor/js/component/Toolbar/CollapsibleToolbar.tsx
@@ -50,7 +50,9 @@ export default class CollapsibleToolbar
       ...(TARGET === "WP"
         ? [
             ".media-modal", // class of the WP media modal
-            ".media-modal-backdrop"
+            ".media-modal-backdrop",
+            ".ui-widget",
+            ".ui-widget-overlay"
           ]
         : [])
     ];

--- a/public/editor-src/editor/js/component/Toolbar/PortalToolbar/index.tsx
+++ b/public/editor-src/editor/js/component/Toolbar/PortalToolbar/index.tsx
@@ -218,7 +218,9 @@ export default class PortalToolbar
       ...(TARGET === "WP"
         ? [
             ".media-modal", // class of the WP media modal
-            ".media-modal-backdrop"
+            ".media-modal-backdrop",
+            ".ui-widget",
+            ".ui-widget-overlay"
           ]
         : []),
       this.clickOutsideException // makes the toolbar not rerender when clicking repeatedly on the same node


### PR DESCRIPTION
I am trying to add support for my plugin (https://wordpress.org/plugins/stockpack/) since one of your customers requested it, but because I use the jquery dialog in the media library I need this exception added. Let me know if I need to do anything else. 