### PR TITLE
fix: image editor doesn't work when image type is webp

### DIFF
--- a/editor/asset/static-file-trait.php
+++ b/editor/asset/static-file-trait.php
@@ -198,6 +198,7 @@ trait Brizy_Editor_Asset_StaticFileTrait {
 			'tif'  => 'image/tiff',
 			'svg'  => 'image/svg+xml',
 			'svgz' => 'image/svg+xml',
+			'webp' => 'image/webp',
 
 			// archives
 			'zip'  => 'application/zip',


### PR DESCRIPTION
https://github.com/bagrinsergiu/blox-editor/issues/14105