### PR TITLE
feat: Added support for placeholders in Wordpress and SMTP form integ…

### DIFF
--- a/brizy.php
+++ b/brizy.php
@@ -17,7 +17,7 @@ if ( isset( $_SERVER['HTTP_X_FORWARDED_PROTO'] ) && stripos( $_SERVER['HTTP_X_FO
 	$_SERVER['HTTPS'] = 'on';
 }
 
-define( 'BRIZY_DEVELOPMENT', false );
+define( 'BRIZY_DEVELOPMENT', true );
 define( 'BRIZY_LOG', false );
 define( 'BRIZY_VERSION', '2.2.10' );
 define( 'BRIZY_EDITOR_VERSION', BRIZY_DEVELOPMENT ? 'dev' : '176-wp' );

--- a/editor/forms/wordpress-integration.php
+++ b/editor/forms/wordpress-integration.php
@@ -104,7 +104,7 @@ class Brizy_Editor_Forms_WordpressIntegration extends Brizy_Editor_Forms_Abstrac
 		}
 
 		return wp_mail(
-			$this->getEmailTo(),
+            apply_filters( 'brizy_form_email_to', $this->getEmailTo(), $fields, $form ),
 			$email_subject,
 			$email_body,
 			$headers


### PR DESCRIPTION
…ration

All fields are available as placeholders:
Ex: {{field_label}}
Also emails for all user except for subscribers:
Ex {{email_[user_login]}}, {{email_[user_nicename]}} or {{email_[display_name]}}