### PR TITLE
Fix: #16581 - extend pQuery to not use html_entity_decode

### DIFF
--- a/compatibilities/woocommerce.php
+++ b/compatibilities/woocommerce.php
@@ -42,7 +42,7 @@ class Brizy_Compatibilities_Woocommerce {
 			return $content;
 		}
 
-	    $dom = pQuery::parseStr( $content );
+	    $dom = Brizy_Parser_Pquery::parseStr( $content );
 
 	    $dom->query('section.brz-section__header')->after( $notices );
 

--- a/parser/dom-node.php
+++ b/parser/dom-node.php
@@ -1,0 +1,11 @@
+<?php
+
+class Brizy_Parser_DomNode extends pQuery\DomNode {
+	/**
+	 * Similar to JavaScript innerText, will return (html formatted) content
+	 * @return string
+	 */
+	function getInnerText() {
+		return $this->toString( true, true, 1 );
+	}
+}

--- a/parser/pquery.php
+++ b/parser/pquery.php
@@ -1,0 +1,17 @@
+<?php
+
+class Brizy_Parser_Pquery extends pQuery {
+
+	/**
+	 * Query a string of html.
+	 *
+	 * @param string $html
+	 *
+	 * @return pQuery\DomNode Returns the root dom node for the html string.
+	 */
+	public static function parseStr( $html ) {
+		$parser = new pQuery\Html5Parser( $html, 0, new Brizy_Parser_DomNode( '~root~', null ) );
+
+		return $parser->root;
+	}
+}


### PR DESCRIPTION
https://github.com/bagrinsergiu/blox-editor/issues/16581