### PR TITLE
fix(api-client) : Saved block tag not removing

### DIFF
--- a/public/editor-client/src/api/index.ts
+++ b/public/editor-client/src/api/index.ts
@@ -318,7 +318,13 @@ export const updateSavedBlock = (
 
   const { editorVersion, url: _url, hash, actions } = config;
 
-  const { uid, title, tags, dataVersion } = savedBlock;
+  const { uid, title, dataVersion } = savedBlock;
+  let { tags } = savedBlock;
+  // if empty string is passed backend doesn't remove tag
+  // https://github.com/bagrinsergiu/blox-editor/issues/23277#issuecomment-1610911099
+  if (tags === "") {
+    tags = ",";
+  }
   const body = new URLSearchParams({
     uid,
     ...(title && { title }),
@@ -519,7 +525,14 @@ export const updateSavedLayout = (
 
   const { editorVersion, url: _url, hash, actions } = config;
 
-  const { uid, title, tags, dataVersion } = savedLayout;
+  const { uid, title, dataVersion } = savedLayout;
+  let { tags } = savedLayout;
+  // if empty string is passed backend doesn't remove tag
+  // https://github.com/bagrinsergiu/blox-editor/issues/23277#issuecomment-1610911099
+  if (tags === "") {
+    tags = ",";
+  }
+
   const body = new URLSearchParams({
     uid,
     ...(title && { title }),


### PR DESCRIPTION
Related to https://github.com/bagrinsergiu/blox-editor/issues/23277

[wordressRemoveTag.webm](https://github.com/ThemeFuse/Brizy/assets/40203375/104474a5-4762-4dd5-a923-b207db34353b)


### After change

[afterWPTagRemove.webm](https://github.com/ThemeFuse/Brizy/assets/40203375/a4267d94-16e2-4c7b-a00e-2cdad69a895d)
