### PR TITLE
new: Added 4 urls for all types of screenshots.

### DIFF
--- a/editor/editor/editor.php
+++ b/editor/editor/editor.php
@@ -82,13 +82,14 @@ class Brizy_Editor_Editor_Editor {
         }
 
 		$config = [
-			'hash'            => wp_create_nonce( Brizy_Editor_API::nonce ),
-			'editorVersion'   => BRIZY_EDITOR_VERSION,
-			'url'             => set_url_scheme( admin_url( 'admin-ajax.php' ) ),
-			'actions'         => $this->getApiActions(),
-			'pageId'          => $this->post->getWpPostId(),
-            'collectionTypes' => $editorConfig['wp']['postLoopSources']
-        ];
+			'prefix'            => Brizy_Editor::prefix(),
+			'hash'               => wp_create_nonce( Brizy_Editor_API::nonce ),
+			'editorVersion'      => BRIZY_EDITOR_VERSION,
+			'url'                => set_url_scheme( admin_url( 'admin-ajax.php' ) ),
+			'actions'            => $this->getApiActions(),
+			'pageId'             => $this->post->getWpPostId(),
+			'collectionTypes'    => $editorConfig['wp']['postLoopSources']
+		];
 
 		$config = $this->getApiConfigFields( $config, $context );
 

--- a/editor/editor/editor.php
+++ b/editor/editor/editor.php
@@ -358,19 +358,27 @@ class Brizy_Editor_Editor_Editor {
 
 
 	private function getApiConfigFields( $config, $context ) {
-		$config['api'] = [
-			'media'      => [
+
+		$screenshotManager = new Brizy_Editor_Screenshot_Manager( $this->urlBuilder );
+		$config['api']     = [
+			'media'       => [
 				'mediaResizeUrl' => home_url()
 			],
 			'customFile' => [
 				'customFileUrl'  => home_url()
 			],
-            'templates'  => [
-                'kitsUrl'    => Brizy_Config::getEditorTemplatesUrl('kits'),
-                'layoutsUrl' => Brizy_Config::getEditorTemplatesUrl('layouts'),
-                'popupsUrl'  => Brizy_Config::getEditorTemplatesUrl('popups'),
-                'storiesUrl' => Brizy_Config::getEditorTemplatesUrl('stories')
-            ]
+			'screenshots' => [
+				'normalScreenshotUrl' => $screenshotManager->getScreenshotBaseUrl( Brizy_Editor_Screenshot_Manager::BLOCK_TYPE_NORMAL, $this->post->getWpPostId() ),
+				'globalScreenshotUrl' => $screenshotManager->getScreenshotBaseUrl( Brizy_Editor_Screenshot_Manager::BLOCK_TYPE_GLOBAL, $this->post->getWpPostId() ),
+				'layoutScreenshotUrl' => $screenshotManager->getScreenshotBaseUrl( Brizy_Editor_Screenshot_Manager::BLOCK_TYPE_LAYOUT, $this->post->getWpPostId() ),
+				'savedScreenshotUrl'  => $screenshotManager->getScreenshotBaseUrl( Brizy_Editor_Screenshot_Manager::BLOCK_TYPE_SAVED, $this->post->getWpPostId() ),
+			],
+			'templates'   => [
+				'kitsUrl'    => Brizy_Config::getEditorTemplatesUrl( 'kits' ),
+				'layoutsUrl' => Brizy_Config::getEditorTemplatesUrl( 'layouts' ),
+				'popupsUrl'  => Brizy_Config::getEditorTemplatesUrl( 'popups' ),
+				'storiesUrl' => Brizy_Config::getEditorTemplatesUrl( 'stories' )
+			]
 		];
 
 		return $config;

--- a/editor/screenshot/manager.php
+++ b/editor/screenshot/manager.php
@@ -31,7 +31,7 @@ class Brizy_Editor_Screenshot_Manager {
 	 * @return bool
 	 */
 	public function saveScreenshot( $screenUid, $blockType, $imageContent, $postId ) {
-		$path = $this->getScreenshotPath( $screenUid, $blockType, $postId );
+		$path = $this->getScreenshotPath( $blockType, $postId );
 
 		if(!$this->validateImageContent( $imageContent )) {
 			throw new Exception('Invalid image content');
@@ -51,7 +51,7 @@ class Brizy_Editor_Screenshot_Manager {
 		$types = array( self::BLOCK_TYPE_NORMAL, self::BLOCK_TYPE_GLOBAL, self::BLOCK_TYPE_SAVED, self::BLOCK_TYPE_LAYOUT );
 
 		foreach ( $types as $type ) {
-			$filePath = $this->getScreenshotPath( $screenUid, $type, $postId );
+			$filePath = $this->getScreenshotPath( $type, $postId );
 
 			$filePath = $filePath . DIRECTORY_SEPARATOR . "{$screenUid}.jpeg";
 
@@ -80,6 +80,29 @@ class Brizy_Editor_Screenshot_Manager {
 				break;
 			case self::BLOCK_TYPE_LAYOUT:
 				$folderPath = $this->urlBuilder->brizy_upload_path( 'blockThumbnails' . DIRECTORY_SEPARATOR . 'layout' );
+				break;
+			default:
+				return null;
+		}
+
+		return $folderPath;
+	}
+
+	public function getScreenshotBaseUrl( $blockType, $postID ) {
+
+		switch ( $blockType ) {
+			case self::BLOCK_TYPE_NORMAL:
+				$this->urlBuilder->set_post_id( $postID );
+				$folderPath = $this->urlBuilder->page_upload_url( 'blockThumbnails' );
+				break;
+			case self::BLOCK_TYPE_GLOBAL:
+				$folderPath = $this->urlBuilder->brizy_upload_url( 'blockThumbnails' . DIRECTORY_SEPARATOR . 'global' );
+				break;
+			case self::BLOCK_TYPE_SAVED:
+				$folderPath = $this->urlBuilder->brizy_upload_url( 'blockThumbnails' . DIRECTORY_SEPARATOR . 'saved' );
+				break;
+			case self::BLOCK_TYPE_LAYOUT:
+				$folderPath = $this->urlBuilder->brizy_upload_url( 'blockThumbnails' . DIRECTORY_SEPARATOR . 'layout' );
 				break;
 			default:
 				return null;


### PR DESCRIPTION
We have 4 types of screenshots and we may have clients that may want to store theses files in different locations.
We decide to add 4 types of base urls for screenshots:

![image](https://github.com/ThemeFuse/Brizy/assets/3128048/4e5b0fe3-b463-44e3-abf8-fc7578ffe980)
