### PR TITLE
Fix : Custom file url path and naming

### DIFF
--- a/editor/editor/editor.php
+++ b/editor/editor/editor.php
@@ -363,7 +363,7 @@ class Brizy_Editor_Editor_Editor {
 				'mediaResizeUrl' => home_url()
 			],
 			'customFile' => [
-				'customFileUrl'  => home_url()
+				'fileUrl'  => home_url( '?' . Brizy_Editor::prefix( '_attachment' ) . '=' ),
 			],
             'templates'  => [
                 'kitsUrl'    => Brizy_Config::getEditorTemplatesUrl('kits'),

--- a/public/editor-client/README.md
+++ b/public/editor-client/README.md
@@ -69,7 +69,7 @@ export interface __BRZ_PLUGIN_ENV__ {
   };
   api: {
     mediaResizeUrl: string;
-    customFileUrl: string;
+    fileUrl: string;
   };
 }
 ```

--- a/public/editor-client/src/config.ts
+++ b/public/editor-client/src/config.ts
@@ -46,7 +46,7 @@ interface Actions {
 
 interface API {
   mediaResizeUrl: string;
-  customFileUrl: string;
+  fileUrl: string;
   templates: DefaultTemplates;
 }
 export interface Config {
@@ -95,14 +95,14 @@ const apiReader = parseStrict<PLUGIN_ENV["api"], API>({
     ),
     throwOnNullish("Invalid actions: mediaResizeUrl")
   ),
-  customFileUrl: pipe(
+  fileUrl: pipe(
     mPipe(
       Obj.readKey("customFile"),
       Obj.read,
-      Obj.readKey("customFileUrl"),
+      Obj.readKey("fileUrl"),
       Str.read
     ),
-    throwOnNullish("Invalid actions: customFileUrl")
+    throwOnNullish("Invalid actions: fileUrl")
   ),
   templates: pipe(
     mPipe(Obj.readKey("templates"), Obj.read, templatesReader),

--- a/public/editor-client/src/index.ts
+++ b/public/editor-client/src/index.ts
@@ -36,7 +36,7 @@ const api = {
   },
   customFile: {
     addFile,
-    customFileUrl: config.api.customFileUrl
+    fileUrl: config.api.fileUrl
   },
   savedBlocks,
   savedPopups,

--- a/public/editor-client/src/types/global.d.ts
+++ b/public/editor-client/src/types/global.d.ts
@@ -33,7 +33,7 @@ export interface PLUGIN_ENV {
   };
   api?: {
     mediaResizeUrl?: string;
-    customFileUrl?: string;
+    fileUrl?: string;
   };
   l10n?: Record<string, string>;
   collectionTypes?: CollectionType[];
@@ -83,7 +83,7 @@ export interface VISUAL_CONFIG {
 
     // File
     customFile?: {
-      customFileUrl?: string;
+      fileUrl?: string;
 
       addFile?: AddFileData;
     };


### PR DESCRIPTION
| Q  | A |
| ------------- | ------------- |
| Screenshot  | N/A  |
| Related tickets	  |  https://github.com/bagrinsergiu/blox-editor/issues/22344   |


### Video

[WPcustomFile.webm](https://github.com/ThemeFuse/Brizy/assets/40203375/e75bd2ef-14aa-4acc-8df3-a6422abcfa22)


### Additional 
Changed naming from ```customFileUrl``` to ```fileUrl``` because of this error in Cloud when naming is ```customFileUrl```
![Screenshot from 2023-08-22 15-43-44](https://github.com/ThemeFuse/Brizy/assets/40203375/dfaa9ad0-82e8-4575-bca0-f0c30096adba)

### Changelog
* Fixed: Changed custom file url path and naming