### PR TITLE
refactor(apiSavedBlocks) : added explicit error messages for saved blocks import

### DIFF
--- a/public/editor-client/src/api/types.ts
+++ b/public/editor-client/src/api/types.ts
@@ -1,0 +1,4 @@
+export interface ErrorResponse {
+  success: false;
+  data: string;
+}

--- a/public/editor-client/src/api/utils.ts
+++ b/public/editor-client/src/api/utils.ts
@@ -3,6 +3,8 @@ import { Dictionary } from "../types/utils";
 import * as Num from "../utils/reader/number";
 import * as Obj from "../utils/reader/object";
 import * as Str from "../utils/reader/string";
+import { MValue } from "../utils/types";
+import { ErrorResponse } from "./types";
 
 export const makeUrl = (
   baseUrl: string,
@@ -68,4 +70,11 @@ export const makeFormEncode = (
   });
 
   return r;
+};
+
+export const getErrorMessage = (e: unknown): MValue<ErrorResponse> => {
+  if (Obj.isObject(e) && "data" in e) {
+    return e as unknown as ErrorResponse;
+  }
+  return undefined;
 };

--- a/public/editor-client/src/savedBlocks/savedBlocks.ts
+++ b/public/editor-client/src/savedBlocks/savedBlocks.ts
@@ -6,6 +6,7 @@ import {
   updateSavedBlock,
   uploadSaveBlocks
 } from "../api";
+import { getErrorMessage } from "../api/utils";
 import { SavedBlockMeta, SavedBlocks } from "../types/SavedBlocks";
 import { createUpload } from "../utils/createUpload";
 import { t } from "../utils/i18n";
@@ -93,7 +94,10 @@ export const savedBlocks: SavedBlocks = {
       res(data);
     } catch (e) {
       console.error("API Client savedBlocks handlerImport:", e);
-      rej(t("Failed to import saved blocks"));
+      const message =
+        getErrorMessage(e)?.data ?? t("Failed to import saved blocks");
+
+      rej(message);
     }
   }
 };

--- a/public/editor-client/src/savedBlocks/savedLayouts.ts
+++ b/public/editor-client/src/savedBlocks/savedLayouts.ts
@@ -6,6 +6,7 @@ import {
   updateSavedLayout,
   uploadSaveLayouts
 } from "../api";
+import { getErrorMessage } from "../api/utils";
 import { SavedLayoutMeta, SavedLayouts } from "../types/SavedBlocks";
 import { createUpload } from "../utils/createUpload";
 import { t } from "../utils/i18n";
@@ -94,7 +95,10 @@ export const savedLayouts: SavedLayouts = {
       res(data);
     } catch (e) {
       console.error("API Client savedLayout handlerImport:", e);
-      rej(t("Failed to import saved layouts"));
+      const message =
+        getErrorMessage(e)?.data ?? t("Failed to import saved layouts");
+
+      rej(message);
     }
   }
 };

--- a/public/editor-client/src/savedBlocks/savedPopups.ts
+++ b/public/editor-client/src/savedBlocks/savedPopups.ts
@@ -6,6 +6,7 @@ import {
   updateSavedBlock,
   uploadSaveBlocks
 } from "../api";
+import { getErrorMessage } from "../api/utils";
 import { SavedBlockMeta, SavedPopups } from "../types/SavedBlocks";
 import { createUpload } from "../utils/createUpload";
 import { t } from "../utils/i18n";
@@ -89,7 +90,10 @@ export const savedPopups: SavedPopups = {
       res(data);
     } catch (e) {
       console.error("API Client savedPopups handlerImport:", e);
-      rej(t("Failed to import saved popups"));
+      const message =
+        getErrorMessage(e)?.data ?? t("Failed to import saved popups");
+
+      rej(message);
     }
   }
 };


### PR DESCRIPTION
| Q  | A |
| ------------- | ------------- |
| Screenshot  | N/A |
| Related tickets	  | https://github.com/bagrinsergiu/Brizy-Cloud/issues/3735 |

![image](https://github.com/bagrinsergiu/blox-editor/assets/40203375/09e07e33-26db-4103-b26f-d18254ab0ba3)

### Before

[beforeWPBlockImport.webm](https://github.com/ThemeFuse/Brizy/assets/40203375/03f45c5e-eb2a-4d3d-81c7-fb66088d3b4f)



### After 

[afterWPBlockImport.webm](https://github.com/ThemeFuse/Brizy/assets/40203375/817e2f6a-3711-45b4-b63b-0c1c2aadb5e8)



### Changelog

* Improved: Explicit error messages for saved blocks import

