### PR TITLE
refactor(apiSavedBlocks) :  changed to descending order for saved blocks

### DIFF
--- a/public/editor-client/src/savedBlocks/savedBlocks.ts
+++ b/public/editor-client/src/savedBlocks/savedBlocks.ts
@@ -23,7 +23,7 @@ export const savedBlocks: SavedBlocks = {
       const get = async (page: number): Promise<void> => {
         const data = await getSavedBlocks({
           page,
-          order: "ASC",
+          order: "DESC",
           count: TOTAL_COUNT
         });
         const normalBlocks = data.filter((item) => item.meta.type === "normal");

--- a/public/editor-client/src/savedBlocks/savedLayouts.ts
+++ b/public/editor-client/src/savedBlocks/savedLayouts.ts
@@ -23,7 +23,7 @@ export const savedLayouts: SavedLayouts = {
       const get = async (page: number): Promise<void> => {
         const data = await getSavedLayouts({
           page,
-          order: "ASC",
+          order: "DESC",
           count: TOTAL_COUNT
         });
         const normalBlocks = data.filter((item) => item.meta.type === "normal");

--- a/public/editor-client/src/savedBlocks/savedPopups.ts
+++ b/public/editor-client/src/savedBlocks/savedPopups.ts
@@ -21,7 +21,11 @@ export const savedPopups: SavedPopups = {
 
       // get savedBLocks with recursive pagination
       const get = async (page: number): Promise<void> => {
-        const data = await getSavedBlocks({ page, count: TOTAL_COUNT });
+        const data = await getSavedBlocks({
+          page,
+          count: TOTAL_COUNT,
+          order: "DESC"
+        });
         const popupBlocks = data.filter((item) => item.meta.type === "popup");
 
         blocks = [...blocks, ...popupBlocks];


### PR DESCRIPTION
| Q  | A |
| ------------- | ------------- |
| Screenshot  |  ![image](https://github.com/bagrinsergiu/blox-editor/assets/40203375/f32261a2-fabe-4402-a0ab-6f251186acd0) |
| Related tickets	  | https://github.com/bagrinsergiu/blox-editor/issues/24395 |

### Aditional

Changed to descending order based on this comment : 
![Screenshot from 2023-12-04 11-34-56](https://github.com/ThemeFuse/Brizy/assets/40203375/9c24bf0c-9d9e-47b1-a4e2-8115de39249b)


### Before
![image](https://github.com/ThemeFuse/Brizy/assets/40203375/0596f49c-75a3-4861-aed1-49b8d9ae498c)


### After
![Screenshot from 2023-12-04 11-12-30](https://github.com/ThemeFuse/Brizy/assets/40203375/abca508b-fc67-4816-a2ed-257d32b24d01)




### Changelog

* Refactor: Descending order for saved blocks
