### PR TITLE
fix: warning on php8.0

### DIFF
--- a/admin/blocks/main.php
+++ b/admin/blocks/main.php
@@ -204,8 +204,8 @@ class Brizy_Admin_Blocks_Main {
 			} else {
 				$ruleMatches[] = [
 					'applyFor'     => Brizy_Admin_Rule::POSTS,
-					'entityType'   => $wpPost->post_type,
-					'entityValues' => [ $wpPost->ID ],
+					'entityType'   => $wpPost ? $wpPost->post_type : null,
+					'entityValues' => $wpPost ? [$wpPost->ID] : [],
 				];
 			}
 		}


### PR DESCRIPTION
This pull request resolves an error reported in Brizy's forum, and also encountered by us.
With this fix, the error no longer appears and the site loads correctly.

errors shown:
``` 
Warning: Attempt to read property "post_type" on null in /public_html/wp-content/plugins/brizy/admin/blocks/main.php on line 207
Warning: Attempt to read property "ID" on null in /public_html/wp-content/plugins/brizy/admin/blocks/main.php on line 208
 ```

forum link: https://support.brizy.io/hc/en-us/community/posts/22112971369234

php version: 8.0