### PR TITLE
Add support for Imagify compatibility

### DIFF
--- a/compatibilities/imagify.php
+++ b/compatibilities/imagify.php
@@ -1,0 +1,22 @@
+<?php
+
+class Brizy_Compatibilities_Imagify {
+
+	public function __construct() {
+        add_filter( 'brizy_after_cropped_img', [ $this, 'brizyAfterCroppedImg' ], 10, 1 );
+    }
+
+	public function brizyAfterCroppedImg($imgUrl) {
+        $webp_image_url = preg_replace( '/\.(jpg|jpeg|png)$/i', '$0.webp', $imgUrl );
+        $webp_image_path = str_replace( home_url(), ABSPATH, $webp_image_url );
+
+        if ( file_exists( $webp_image_path ) ) {
+            return $webp_image_url;
+        }
+
+        return $imgUrl;
+    }
+
+}
+
+

--- a/compatibilities/imagify.php
+++ b/compatibilities/imagify.php
@@ -3,11 +3,12 @@
 class Brizy_Compatibilities_Imagify {
 
     public function __construct() {
-        add_filter( 'brizy_after_cropped_img', [ $this, 'brizyAfterCroppedImg' ], 10, 1 );
+        add_filter( 'brizy_after_cropped_img_url', [ $this, 'brizyAfterCroppedImg' ], 10, 1 );
+        add_filter( 'brizy_after_cropped_img_path', [ $this, 'brizyAfterCroppedImg' ], 10, 1 );
     }
 
     public function brizyAfterCroppedImg( $imgUrl ) {
-        if ( ! isset( $_GET['action'] ) ) {
+        if ( !wp_doing_ajax() && Brizy_Public_Main::is_editing()) {
             $webp_image_url  = preg_replace( '/\.(jpg|jpeg|png)$/i', '$0.webp', $imgUrl );
             $webp_image_path = str_replace( home_url(), ABSPATH, $webp_image_url );
 

--- a/compatibilities/imagify.php
+++ b/compatibilities/imagify.php
@@ -2,21 +2,21 @@
 
 class Brizy_Compatibilities_Imagify {
 
-	public function __construct() {
+    public function __construct() {
         add_filter( 'brizy_after_cropped_img', [ $this, 'brizyAfterCroppedImg' ], 10, 1 );
     }
 
-	public function brizyAfterCroppedImg($imgUrl) {
-        $webp_image_url = preg_replace( '/\.(jpg|jpeg|png)$/i', '$0.webp', $imgUrl );
-        $webp_image_path = str_replace( home_url(), ABSPATH, $webp_image_url );
+    public function brizyAfterCroppedImg( $imgUrl ) {
+        if ( ! isset( $_GET['action'] ) ) {
+            $webp_image_url  = preg_replace( '/\.(jpg|jpeg|png)$/i', '$0.webp', $imgUrl );
+            $webp_image_path = str_replace( home_url(), ABSPATH, $webp_image_url );
 
-        if ( file_exists( $webp_image_path ) ) {
-            return $webp_image_url;
+            if ( file_exists( $webp_image_path ) ) {
+                return $webp_image_url;
+            }
         }
 
         return $imgUrl;
     }
 
 }
-
-

--- a/compatibilities/init.php
+++ b/compatibilities/init.php
@@ -42,7 +42,9 @@ class Brizy_Compatibilities_Init {
 	}
 
 	public function action_plugins_loaded() {
-
+        if ( defined( 'IMAGIFY_VERSION' ) ) {
+            new Brizy_Compatibilities_Imagify();
+        }
 
 		if ( defined( 'SEOPRESS_VERSION' ) ) {
 			new Brizy_Compatibilities_SeoPress();

--- a/editor/crop-cache-media.php
+++ b/editor/crop-cache-media.php
@@ -95,6 +95,11 @@ class Brizy_Editor_CropCacheMedia extends Brizy_Editor_Asset_StaticFile {
 		}
 
 		$originalPath = $this->getOriginalPath( $uid );
+
+        if (!isset($_GET['action'])) {
+            $originalPath = apply_filters( 'brizy_after_cropped_img', $originalPath );
+        }
+
 		$cropper      = new Brizy_Editor_Asset_Crop_Cropper();
 		$options      = $cropper->getFilterOptions( $originalPath, $size, $this->getOrignalImgSizes( $uid ) );
 
@@ -235,7 +240,13 @@ class Brizy_Editor_CropCacheMedia extends Brizy_Editor_Asset_StaticFile {
 			$imgUrl = $this->getImgUrlByWpSize( $uid, 'full' );
 		}
 
-        return $this->replaceCdnUrl($imgUrl);
+        $imgUrl = $this->replaceCdnUrl($imgUrl);
+
+        if (!isset($_GET['action'])) {
+            $imgUrl = apply_filters( 'brizy_after_cropped_img', $imgUrl );
+        }
+
+        return $imgUrl;
     }
 
     /**

--- a/editor/crop-cache-media.php
+++ b/editor/crop-cache-media.php
@@ -96,7 +96,7 @@ class Brizy_Editor_CropCacheMedia extends Brizy_Editor_Asset_StaticFile {
 
 		$originalPath = $this->getOriginalPath( $uid );
 
-       $originalPath = apply_filters( 'brizy_after_cropped_img', $originalPath );
+       $originalPath = apply_filters( 'brizy_after_cropped_img_path', $originalPath );
 
 		$cropper      = new Brizy_Editor_Asset_Crop_Cropper();
 		$options      = $cropper->getFilterOptions( $originalPath, $size, $this->getOrignalImgSizes( $uid ) );
@@ -240,7 +240,7 @@ class Brizy_Editor_CropCacheMedia extends Brizy_Editor_Asset_StaticFile {
 
         $imgUrl = $this->replaceCdnUrl( $imgUrl );
 
-        $imgUrl = apply_filters( 'brizy_after_cropped_img', $imgUrl );
+        $imgUrl = apply_filters( 'brizy_after_cropped_img_url', $imgUrl );
 
         return $imgUrl;
     }

--- a/editor/crop-cache-media.php
+++ b/editor/crop-cache-media.php
@@ -96,9 +96,7 @@ class Brizy_Editor_CropCacheMedia extends Brizy_Editor_Asset_StaticFile {
 
 		$originalPath = $this->getOriginalPath( $uid );
 
-        if (!isset($_GET['action'])) {
-            $originalPath = apply_filters( 'brizy_after_cropped_img', $originalPath );
-        }
+       $originalPath = apply_filters( 'brizy_after_cropped_img', $originalPath );
 
 		$cropper      = new Brizy_Editor_Asset_Crop_Cropper();
 		$options      = $cropper->getFilterOptions( $originalPath, $size, $this->getOrignalImgSizes( $uid ) );
@@ -240,11 +238,9 @@ class Brizy_Editor_CropCacheMedia extends Brizy_Editor_Asset_StaticFile {
 			$imgUrl = $this->getImgUrlByWpSize( $uid, 'full' );
 		}
 
-        $imgUrl = $this->replaceCdnUrl($imgUrl);
+        $imgUrl = $this->replaceCdnUrl( $imgUrl );
 
-        if (!isset($_GET['action'])) {
-            $imgUrl = apply_filters( 'brizy_after_cropped_img', $imgUrl );
-        }
+        $imgUrl = apply_filters( 'brizy_after_cropped_img', $imgUrl );
 
         return $imgUrl;
     }


### PR DESCRIPTION
Introduced a new compatibility class to integrate Imagify's WebP functionality into Brizy's cropped image handling. Applied a filter to replace cropped image URLs with WebP versions when available. This ensures optimized image loading while maintaining backward compatibility.
https://github.com/bagrinsergiu/blox-editor/issues/27341