### PR TITLE
feat(auth): Implement unauthenticated heartbeat for session checking

### DIFF
--- a/editor.php
+++ b/editor.php
@@ -106,7 +106,9 @@ class Brizy_Editor {
 		add_action( 'init', array( $this, 'initializeThirdParty' ), -2000);
         add_action('init', [ $this, 'handleEditorEditMode' ], 0 );
 		add_action( 'wp', [ $this, 'handleEditorPreviewMode' ] );
-	}
+
+        new Brizy_Editor_AuthModal();
+    }
 
 	public function initialize() {
 

--- a/editor/auth-modal.php
+++ b/editor/auth-modal.php
@@ -1,0 +1,149 @@
+<?php if (!defined('ABSPATH')) {
+    die('Direct access forbidden.');
+}
+
+class Brizy_Editor_AuthModal
+{
+    public function __construct()
+    {
+        add_action('wp_footer', [$this, 'authModal']);
+    }
+
+
+    public function authModal()
+    {
+        if (!Brizy_Public_Main::is_editing()) {
+            return;
+        }
+        ?>
+        <style>
+            .brizy-auth-modal {
+                display: none;
+                position: fixed;
+                top: 0;
+                left: 0;
+                width: 100%;
+                height: 100%;
+                background-color: rgba(0, 0, 0, 0.75);
+                z-index: 99999;
+                justify-content: center;
+                align-items: center;
+            }
+
+            .brizy-auth-modal.is-visible {
+                display: flex;
+            }
+
+            .brizy-auth-modal-content {
+                text-align: center;
+            }
+
+            .brizy-auth-modal-content iframe {
+                width: 115%;
+                height: 460px;
+                border-radius: 5px;
+            }
+        </style>
+
+        <div id="brizy-auth-modal" class="brizy-auth-modal">
+            <div class="brizy-auth-modal-content">
+                <iframe
+                    id="brizy-auth-iframe"
+                    src="<?php echo wp_login_url(); ?>"
+                    style="border:0px none #ffffff;"
+                    name="brizyAuthIframe"
+                    scrolling="no"
+                    marginwidth="0"
+                    marginheight="0"
+                ></iframe>
+            </div>
+        </div>
+
+        <script>
+            document.addEventListener('DOMContentLoaded', function () {
+                var authModal = document.getElementById('brizy-auth-modal');
+                var ajaxurl = "<?php echo admin_url('admin-ajax.php'); ?>";
+                var iframe = document.getElementById('brizy-auth-iframe');
+
+                setInterval(function () {
+                    jQuery.ajax({
+                        type: 'POST',
+                        url: ajaxurl,
+                        data: {
+                            'action': 'brizy_auth_status'
+                        },
+                        dataType: 'json',
+                        complete: function (xhr, status) {
+                            if (xhr.responseJSON && xhr.responseJSON.data && xhr.responseJSON.data.logged === true) {
+                                if (typeof __BRZ_PLUGIN_ENV__ !== 'undefined') {
+                                    __BRZ_PLUGIN_ENV__.hash = xhr.responseJSON.data.nonce;
+                                }
+                                closeAuthModal();
+                            } else {
+                                openAuthModal();
+                            }
+                        }
+                    });
+                }, 5000);
+
+                function openAuthModal() {
+                    if (authModal.classList.contains('is-visible')) {
+                        return;
+                    }
+
+                    iframe.src = "<?php echo wp_login_url('', true).'&interim-login=1'; ?>";
+
+                    setTimeout(function () {
+                        authModal.classList.add('is-visible');
+                    }, 500);
+
+                    iframe.onload = function () {
+                        try {
+                            var iframeContent = iframe.contentWindow.document;
+                            var loginForm = iframeContent.getElementById('loginform');
+
+                            if (loginForm) {
+                                loginForm.addEventListener('submit', function (e) {
+                                    e.preventDefault();
+
+                                    var formData = new FormData(loginForm);
+                                    formData.append('action', 'brizy_login_handler');
+
+                                    jQuery.ajax({
+                                        type: 'POST',
+                                        dataType: 'json',
+                                        url: ajaxurl,
+                                        data: Object.fromEntries(formData.entries()),
+                                        success: function (response) {
+                                            if (response.success) {
+                                                if (typeof __BRZ_PLUGIN_ENV__ !== 'undefined') {
+                                                    __BRZ_PLUGIN_ENV__.hash = response.data.nonce;
+                                                }
+                                                closeAuthModal();
+                                            } else {
+                                                var errorMessage = iframeContent.getElementById('login-error-message');
+                                                if (errorMessage) {
+                                                    errorMessage.textContent = response.data.message;
+                                                    errorMessage.style.display = 'block';
+                                                }
+                                            }
+                                        },
+                                        error: function (xhr, status, error) {
+                                        }
+                                    });
+                                });
+                            }
+                        } catch (e) {
+                        }
+                    };
+                }
+
+                function closeAuthModal() {
+                    authModal.classList.remove('is-visible');
+                }
+            });
+        </script>
+        <?php
+    }
+
+}

--- a/editor/forms/api.php
+++ b/editor/forms/api.php
@@ -28,6 +28,9 @@ class Brizy_Editor_Forms_Api
 
     const AJAX_AUTHENTICATION_CALLBACK = '_authentication_callback';
 
+    const AJAX_AUTH_STATUS = '_auth_status';
+    const AJAX_LOGIN_HANDLER = '_login_handler';
+
     /**
      * @var Brizy_Editor_Post
      */
@@ -68,14 +71,61 @@ class Brizy_Editor_Forms_Api
             add_action($pref . self::AJAX_GET_INTEGRATION, array($this, 'getIntegration'));
             add_action($pref . self::AJAX_UPDATE_INTEGRATION, array($this, 'updateIntegration'));
             add_action($pref . self::AJAX_DELETE_INTEGRATION, array($this, 'deleteIntegration'));
+            add_action($pref . self::AJAX_AUTH_STATUS, array($this, 'updateAuthStatus'));
         }
 
         add_filter('brizy_form_submit_data', array($this, 'handleFileTypeFields'), -100, 2);
 
         add_action($pref . self::AJAX_SUBMIT_FORM, array($this, 'submit_form'));
         add_action($pref_nopriv . self::AJAX_SUBMIT_FORM, array($this, 'submit_form'));
+
+        add_action($pref_nopriv . self::AJAX_AUTH_STATUS, array($this, 'updateAuthStatus'));
+        add_action($pref_nopriv . self::AJAX_LOGIN_HANDLER, array($this, 'submitLoginHandler'));
     }
 
+    function updateAuthStatus()
+    {
+        if (is_user_logged_in()) {
+            $nonce = 'brizy-api';
+
+            wp_send_json_success(array(
+                'logged' => true,
+                'nonce'  => wp_create_nonce($nonce)
+            ));
+        } else {
+            wp_send_json_success(array(
+                'logged' => false
+            ));
+        }
+
+        exit;
+    }
+
+    function submitLoginHandler()
+    {
+        $creds = array();
+
+        $creds['user_login']    = $_POST['log'];
+        $creds['user_password'] = $_POST['pwd'];
+        $creds['remember']      = isset($_POST['rememberme']);
+
+        $user = wp_signon($creds, false);
+
+        if (is_wp_error($user)) {
+            wp_send_json_error(array(
+                'message' => $user->get_error_message()
+            ));
+        } else {
+            $nonce = 'brizy-api';
+
+            wp_send_json_success(array(
+                'logged' => true,
+                'nonce'  => wp_create_nonce($nonce)
+            ));
+        }
+
+        exit;
+    }
 
     protected function error($code, $message)
     {


### PR DESCRIPTION
Introduces a heartbeat mechanism to periodically check the user's authentication status from the frontend. This will be used to detect if the user's session has expired and prompt them to log in again.

- Added a JavaScript snippet to `wp_footer` that sends a periodic AJAX request to the `brizy_heartbeat` action.
- The `brizy_heartbeat` action now checks the user's login status.
- Nonce verification for the heartbeat has been disabled to allow checks from logged-out users.
- The heartbeat interval in the editor has been reduced.
- Removed an old functional test for the previous heartbeat implementation.