### PR TITLE
feat(dc): add CONFIG_KEY_EMBED constant for embed dynamic content type

### DIFF
--- a/content/providers/interface.php
+++ b/content/providers/interface.php
@@ -6,6 +6,7 @@ interface Brizy_Content_Providers_Interface {
 	const CONFIG_KEY_IMAGE    = 'image';
 	const CONFIG_KEY_LINK     = 'link';
 	const CONFIG_KEY_OEMBED   = 'oembed';
+	const CONFIG_KEY_EMBED    = 'embed';
 	const CONFIG_KEY_VIDEO    = 'video';
 	const CONFIG_KEY_SNDCLOUD = 'sndcloud';
 }


### PR DESCRIPTION
Add embed = 'embed' constant to provider interface to support the new DCTypes.embed added on the frontend (blox-editor PR #31091).