### PR TITLE
Add WP Rocket and WP Fastest Cache compatibility

### DIFF
--- a/compatibilities/init.php
+++ b/compatibilities/init.php
@@ -98,6 +98,12 @@ class Brizy_Compatibilities_Init {
 		if ( defined( 'PERFMATTERS_VERSION' ) ) {
 			new Brizy_Compatibilities_Perfmatters();
 		}
+		if ( defined( 'WP_ROCKET_VERSION' ) ) {
+			new Brizy_Compatibilities_WpRocket();
+		}
+		if ( class_exists( 'WpFastestCache' ) ) {
+			new Brizy_Compatibilities_WpFastestCache();
+		}
 		if ( class_exists( 'COMPLIANZ' ) ) {
 			new Brizy_Compatibilities_ComplianzGpdr();
 		}

--- a/compatibilities/wp-fastest-cache.php
+++ b/compatibilities/wp-fastest-cache.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * Compatibility with WP Fastest Cache plugin: https://wordpress.org/plugins/wp-fastest-cache/
+ *
+ * WP Fastest Cache combines/minifies JS (and with "Render Blocking JS" moves it
+ * around), which reorders Brizy's frontend bundles relative to their inline init
+ * scripts and breaks menu/slider initialization - most visibly the mobile menu.
+ *
+ * WP Fastest Cache exposes very few filters, but its JS optimizer skips any
+ * <script> carrying a `data-no-minify` attribute (see inc/js-utilities.php).
+ * We tag Brizy's own frontend scripts and styles with it so they keep their
+ * original order and remain inline-script compatible.
+ */
+class Brizy_Compatibilities_WpFastestCache {
+
+	public function __construct() {
+		add_filter( 'script_loader_tag', [ $this, 'excludeScript' ], 11, 3 );
+		add_filter( 'style_loader_tag', [ $this, 'excludeStyle' ], 11, 3 );
+	}
+
+	/**
+	 * @param string $tag
+	 * @param string $handle
+	 * @param string $src
+	 *
+	 * @return string
+	 */
+	public function excludeScript( $tag, $handle, $src ) {
+		if ( $this->isBrizyAsset( $handle, $src ) && strpos( $tag, 'data-no-minify' ) === false ) {
+			$tag = preg_replace( '/<script\s/', '<script data-no-minify="1" ', $tag, 1 );
+		}
+
+		return $tag;
+	}
+
+	/**
+	 * @param string $tag
+	 * @param string $handle
+	 * @param string $src
+	 *
+	 * @return string
+	 */
+	public function excludeStyle( $tag, $handle, $src ) {
+		if ( $this->isBrizyAsset( $handle, $src ) && strpos( $tag, 'data-no-minify' ) === false ) {
+			$tag = preg_replace( '/<link\s/', '<link data-no-minify="1" ', $tag, 1 );
+		}
+
+		return $tag;
+	}
+
+	/**
+	 * @param string $handle
+	 * @param string $src
+	 *
+	 * @return bool
+	 */
+	private function isBrizyAsset( $handle, $src ) {
+		if ( strpos( (string) $handle, 'brizy' ) === 0 ) {
+			return true;
+		}
+
+		return strpos( (string) $src, '/plugins/brizy/public/' ) !== false
+			|| strpos( (string) $src, '/plugins/brizy-pro/public/' ) !== false;
+	}
+}

--- a/compatibilities/wp-rocket.php
+++ b/compatibilities/wp-rocket.php
@@ -1,0 +1,98 @@
+<?php
+
+/**
+ * Compatibility with WP Rocket plugin: https://wp-rocket.me/
+ *
+ * Brizy renders sliders, menus (including the mobile mm-menu) and animations
+ * with JavaScript that must run on page load. WP Rocket's "Delay JavaScript
+ * execution" and "Load JavaScript deferred" stop that JS - both Brizy's external
+ * bundles and its inline init scripts - from running until the first user
+ * interaction, leaving sliders and menus broken on the public page. "Remove
+ * Unused CSS" additionally strips Brizy classes that are only added at runtime
+ * by that same JS, which breaks/flashes the menu.
+ *
+ * This class auto-excludes Brizy assets from those features so users can keep
+ * WP Rocket optimizations enabled, and fully bypasses WP Rocket while editing.
+ */
+class Brizy_Compatibilities_WpRocket {
+
+	public function __construct() {
+		add_action( 'plugins_loaded', [ $this, 'bypassWhileEditing' ], 1 );
+
+		add_filter( 'rocket_delay_js_exclusions', [ $this, 'excludeDelayJs' ] );
+		add_filter( 'rocket_exclude_defer_js', [ $this, 'excludeScriptUrls' ] );
+		add_filter( 'rocket_exclude_js', [ $this, 'excludeScriptUrls' ] );
+		add_filter( 'rocket_excluded_inline_js_content', [ $this, 'excludeInlineContent' ] );
+		add_filter( 'rocket_rucss_safelist', [ $this, 'safelistCss' ] );
+	}
+
+	/**
+	 * The editor and its preview iframe are served as frontend HTML, so WP Rocket
+	 * would delay/defer the editor scripts and break it. Disable all optimization
+	 * there, the same way the other optimization compatibilities do.
+	 */
+	public function bypassWhileEditing() {
+		if ( Brizy_Public_Main::is_editing() && ! defined( 'DONOTROCKETOPTIMIZE' ) ) {
+			define( 'DONOTROCKETOPTIMIZE', true );
+		}
+	}
+
+	/**
+	 * Delay JS matches each pattern against the whole <script> tag, so this
+	 * covers both Brizy's external bundles (by src) and its inline init scripts
+	 * (by their wp_add_inline_script id: brizy-preview, brizy-asset-*).
+	 *
+	 * @param array $excluded
+	 *
+	 * @return array
+	 */
+	public function excludeDelayJs( $excluded ) {
+		return array_merge( (array) $excluded, [
+			'/wp-content/plugins/brizy/public/',
+			'/wp-content/plugins/brizy-pro/public/',
+			'id=.brizy-',
+			'__CONFIG__',
+		] );
+	}
+
+	/**
+	 * @param array $excluded
+	 *
+	 * @return array
+	 */
+	public function excludeScriptUrls( $excluded ) {
+		return array_merge( (array) $excluded, [
+			'/wp-content/plugins/brizy/public/',
+			'/wp-content/plugins/brizy-pro/public/',
+		] );
+	}
+
+	/**
+	 * @param array $excluded
+	 *
+	 * @return array
+	 */
+	public function excludeInlineContent( $excluded ) {
+		return array_merge( (array) $excluded, [
+			'__CONFIG__',
+			'__VISUAL_CONFIG__',
+		] );
+	}
+
+	/**
+	 * Brizy toggles these classes on the menu/slider at runtime, so Remove
+	 * Unused CSS cannot see them in the static HTML and would strip them.
+	 *
+	 * @param array $safelist
+	 *
+	 * @return array
+	 */
+	public function safelistCss( $safelist ) {
+		return array_merge( (array) $safelist, [
+			'/^brz-/',
+			'(.*)brz-slick-slider(.*)',
+			'(.*)brz-menu(.*)',
+			'(.*)brz-mm-menu(.*)',
+		] );
+	}
+}

--- a/compatibilities/wp-rocket.php
+++ b/compatibilities/wp-rocket.php
@@ -42,6 +42,10 @@ class Brizy_Compatibilities_WpRocket {
 	 * covers both Brizy's external bundles (by src) and its inline init scripts
 	 * (by their wp_add_inline_script id: brizy-preview, brizy-asset-*).
 	 *
+	 * Brizy's bundles use jQuery ($), so once they are excluded from delay they
+	 * run at parse time - jQuery must be excluded too or they hit "$ is not
+	 * defined" and the group-all/preview modules fail to register.
+	 *
 	 * @param array $excluded
 	 *
 	 * @return array
@@ -52,6 +56,8 @@ class Brizy_Compatibilities_WpRocket {
 			'/wp-content/plugins/brizy-pro/public/',
 			'id=.brizy-',
 			'__CONFIG__',
+			'/wp-includes/js/jquery/jquery.min.js',
+			'/wp-includes/js/jquery/jquery-migrate.min.js',
 		] );
 	}
 


### PR DESCRIPTION
Brizy frontend sliders/menus rely on JS that must run on load. WP Rocket's delay/defer JS and Remove Unused CSS, and WP Fastest Cache's JS combine, break that JS on the public page (BRZ-692).

- wp-rocket.php: exclude Brizy assets from delay/defer JS, safelist brz- classes from RUCSS, bypass optimization while editing.
- wp-fastest-cache.php: tag Brizy script/style tags with data-no-minify so WPFC keeps their load order.
- init.php: register both when the respective plugin is active.