### PR TITLE
feat: white label the AI page generator

### DIFF
--- a/admin/main.php
+++ b/admin/main.php
@@ -260,6 +260,7 @@ class Brizy_Admin_Main {
                 'aiNonce'       => wp_create_nonce( 'brizy-api' ),
                 'nonce'         => wp_create_nonce( 'brizy-admin-nonce' ),
                 'isWhiteLabel'  => apply_filters( 'brizy_wl_enabled', false ),
+                'isAiEnabled'   => Brizy_Config::isAiEnabled(),
                 'l10n'          => [
                         'deactivateFeedbackSubmitBtn' => __( 'Submit & Deactivate', 'brizy' ),
                         'deactivateFeedbackSkipBtn'   => __( 'Skip & Deactivate', 'brizy' ),

--- a/admin/static/js/script.js
+++ b/admin/static/js/script.js
@@ -193,7 +193,7 @@ jQuery(document).ready(function ($) {
 
         isAvailable: function () {
             return typeof Brizy_Admin_Data !== 'undefined' &&
-                !Brizy_Admin_Data.isWhiteLabel &&
+                Brizy_Admin_Data.isAiEnabled &&
                 Brizy_Admin_Data.aiActions &&
                 Object.keys(Brizy_Admin_Data.aiActions).length > 0;
         },

--- a/config.dev.php
+++ b/config.dev.php
@@ -123,6 +123,16 @@ class Brizy_Config
         return __bt('support-url', apply_filters('brizy_support_url', self::SUPPORT_URL));
     }
 
+    static public function getAiUrl()
+    {
+        return rtrim(__bt('ai-url', self::GENERATE_GLOBAL_STYLES_ENDPOINT), '/');
+    }
+
+    static public function isAiEnabled()
+    {
+        return (bool)apply_filters('brizy_ai_enabled', !apply_filters('brizy_wl_enabled', false));
+    }
+
     static private function getEnvValue($name)
     {
         $value = isset($_ENV[$name]) ? $_ENV[$name] : null;

--- a/config.php
+++ b/config.php
@@ -120,6 +120,16 @@ class Brizy_Config
         return __bt('support-url', apply_filters('brizy_support_url', self::SUPPORT_URL));
     }
 
+    static public function getAiUrl()
+    {
+        return rtrim(__bt('ai-url', self::GENERATE_GLOBAL_STYLES_ENDPOINT), '/');
+    }
+
+    static public function isAiEnabled()
+    {
+        return (bool)apply_filters('brizy_ai_enabled', !apply_filters('brizy_wl_enabled', false));
+    }
+
     static public function getUpgradeUrl()
     {
         return apply_filters('brizy_upgrade_to_pro_url', self::UPGRADE_TO_PRO_URL);

--- a/import/main.php
+++ b/import/main.php
@@ -52,6 +52,7 @@ class Brizy_Import_Main
 
         $args = [
             'isWhiteLabel' => $isWhiteLabel,
+            'isAiEnabled' => Brizy_Config::isAiEnabled(),
             'l10n' => [
                 'all' => __('All', 'brizy'),
                 'livePreview' => __('Live Preview', 'brizy'),
@@ -86,9 +87,10 @@ class Brizy_Import_Main
                 'aiBannerFeature1' => __('Usable websites, no gimmicks', 'brizy'),
                 'aiBannerFeature2' => __('Tailor-made texts & images included', 'brizy'),
                 'aiBannerFeature3' => __('Full editing control after generation', 'brizy'),
-                'aiBrizy' => __('AI Brizy', 'brizy'),
+                'aiBrizy' => sprintf(__('AI %s', 'brizy'), __bt('brizy', 'Brizy')),
                 'aiLogoAlt' => __('AI', 'brizy'),
             ],
+            'aiLogo' => apply_filters('brizy_wl_enabled', false) ? __bt('brizy-logo', '') : '',
             'supportUrl' => Brizy_Config::getSupportUrl(),
             'goProUrl' => Brizy_Config::getUpgradeUrl(),
             'isPro' => Brizy_Compatibilities_BrizyProCompatibility::isPro(),

--- a/import/static/css/ai-banner.css
+++ b/import/static/css/ai-banner.css
@@ -221,6 +221,15 @@
     display: block;
 }
 
+/* White label logo */
+.brz-ai-logo-container img {
+    display: block;
+    width: auto;
+    height: auto;
+    max-width: 200px;
+    max-height: 76px;
+}
+
 /* Responsive Breakpoints */
 @media screen and (max-width: 1024px) {
     .brz-ai-banner {
@@ -305,7 +314,8 @@
         width: 100% !important;
     }
 
-    .brz-ai-banner-right .brz-ai-logo-container svg {
+    .brz-ai-banner-right .brz-ai-logo-container svg,
+    .brz-ai-banner-right .brz-ai-logo-container img {
         width: clamp(70px, 20vw, 100px) !important;
         height: auto !important;
         max-width: 100px !important;
@@ -352,7 +362,8 @@
         padding: 12px !important;
     }
 
-    .brz-ai-banner-right .brz-ai-logo-container svg {
+    .brz-ai-banner-right .brz-ai-logo-container svg,
+    .brz-ai-banner-right .brz-ai-logo-container img {
         width: clamp(60px, 18vw, 80px) !important;
         max-width: 80px !important;
     }

--- a/import/views/starter-templates.php
+++ b/import/views/starter-templates.php
@@ -24,7 +24,7 @@
         </form>
     </div>
 
-    <?php if ( empty( $isWhiteLabel ) && ! empty( $isPro ) ) : ?>
+    <?php if ( ! empty( $isAiEnabled ) && ! empty( $isPro ) ) : ?>
     <div class="brz-ai-banner">
         <div class="brz-ai-banner-bg-circle"></div>
 
@@ -98,8 +98,11 @@
         </div>
 
         <div class="brz-ai-banner-right">
-            <a href="https://ai.brizy.io/" target="_blank" rel="noopener noreferrer" title="<?php echo esc_attr($l10n['aiBrizy']); ?>" class="brz-ai-logo-link">
+            <a href="<?php echo esc_url(Brizy_Config::getAiUrl() . '/'); ?>" target="_blank" rel="noopener noreferrer" title="<?php echo esc_attr($l10n['aiBrizy']); ?>" class="brz-ai-logo-link">
                 <div class="brz-ai-logo-container">
+                    <?php if (!empty($aiLogo)): ?>
+                    <img class="brz-ai-logo-img" src="<?php echo esc_url($aiLogo); ?>" alt="<?php echo esc_attr($l10n['aiBrizy']); ?>">
+                    <?php else: ?>
                     <svg width="200px" height="76px" viewBox="0 0 113.968401 43.0000985" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" role="img" aria-label="<?php echo esc_attr($l10n['aiLogoAlt']); ?>">
                         <title>Brizy</title>
                         <defs>
@@ -117,6 +120,7 @@
                             </g>
                         </g>
                     </svg>
+                    <?php endif; ?>
                 </div>
             </a>
         </div>


### PR DESCRIPTION
Companion PR: `Brizy-Pro` branch `feat-white-label-ai-generator` (the white label settings live there).

## Problem

The AI page generator URL was hardcoded to `ai.brizy.io` in several places, and the whole feature was hard-disabled whenever white label was on.

## What changed

- `Brizy_Config::getAiUrl()` resolves the AI base url from the new white label `ai-url` value via `__bt()`, falling back to `ai.brizy.io` when empty. Used by the starter templates banner link.
- `Brizy_Config::isAiEnabled()` is the single gate for the feature, backed by the new `brizy_ai_enabled` filter. Default keeps today's behaviour for non white label sites.
- Both gates that used to check `isWhiteLabel` now check `isAiEnabled`:
  - `import/views/starter-templates.php` — the AI banner
  - `admin/static/js/script.js` — the "Generate With X - AI" button on the post edit screen
- The banner renders the white label logo and company name instead of the hardcoded Brizy logo and the `AI Brizy` label.
- `config.dev.php` kept in parity with `config.php`.

## Behaviour

| Site | AI banner + button |
| --- | --- |
| No white label, Pro | on (unchanged) |
| White label, AI toggle off (default) | off — unchanged from today |
| White label, AI toggle on | on, with their logo, name and AI URL |

## Notes

- `editor/editor/editor.php` was intentionally left alone — `aiGlobalStyleUrl` is not user visible.
- `GENERATE_GLOBAL_STYLES_ENDPOINT` is still the fallback constant, unchanged.

## Testing

- [ ] Non white label Pro site: banner and post edit button still appear, link still goes to `ai.brizy.io`
- [ ] White label with AI toggle off: no banner, no button, AI ajax actions unregistered
- [ ] White label with AI toggle on and a custom AI URL: banner shows their logo, link goes to their url
- [ ] White label with AI toggle on and no AI URL: falls back to `ai.brizy.io`
- [ ] Banner logo renders sanely at mobile breakpoints
