### PR TITLE
fix(editor): use site_url() instead of home_url() for wp-content asset paths

### DIFF
--- a/editor/url-builder.php
+++ b/editor/url-builder.php
@@ -430,7 +430,7 @@ class Brizy_Editor_UrlBuilder {
 			$path = substr($path, strpos($path,"/wp-content"));
 		}
 
-		$urlInfo = parse_url( home_url( $path ) );
+		$urlInfo = parse_url( site_url( $path ) );
 		$portPart = "";
 		if(isset($urlInfo['port']))
 		{


### PR DESCRIPTION
Compiled/element CSS & JS bundles 404 on the front end when siteurl and home url point at different paths (e.g. WordPress installed under a subdirectory while the site is served from the root domain), because asset_url() rebuilt the wp-content-relative path against home_url() instead of the installation's own siteurl.

BRZ-1320